### PR TITLE
Added Pairmatch Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ usage: IOTools.py <command> [<args>]
 
 Currently available commands include:
    pairgen       Outputs a series of seed-hash pairs for files generated using the RandomIO library.
+   pairmatch     Outputs the hash of a file when given the seed and byte size.
 
 A series of command-line tools that make use of the RandomIO library.
 
@@ -95,11 +96,11 @@ optional arguments:
   -h, --help  show this help message and exit
 ```
 
-Currently, `pairgen` is the only available tool:
+Currently, `pairgen` and `pairmatch` are the only available tools:
 
 ```
 $ IOTools.py pairgen --help
-usage: IOTools.py [-h] [-l LENGTH] [-p PAIRS] [-o OUTPUT] [-v] size
+usage: IOTools.py pairgen [-h] [-l LENGTH] [-p PAIRS] [-o OUTPUT] [-v] size
 
 Output a series of seed-hash pairs for files generated in memory using the
 RandomIO library.
@@ -144,6 +145,24 @@ Note that files are generated and hashed in memory. In addition, seeds displayed
 When writing pairs to file using Redis's mass insertion format, you can use the following command to import your pairs to Redis:
 
 `cat pairs.out | redis-cli --pipe`
+
+```
+$ IOTools.py pairmatch --help
+usage: IOTools.py pairmatch [-h] size seed
+
+positional arguments:
+  size                  The target size of each file generated and hashed (in
+                        bytes).
+  seed                  The seed of the file that you want to generate a hash
+                        for.
+```
+
+Example output of `pairmatch`:
+
+```
+$ IOTools.py pairmatch 1000000 44f3c93879b0e9474d5e
+5f2a3116b9894e2bc9186452502251b70636be4cfb5a4e898f162962f22c7125
+```
 
 ### Performance
 

--- a/bin/IOTools.py
+++ b/bin/IOTools.py
@@ -93,13 +93,26 @@ Currently available commands include:
                     print('Pair {0}: Generating hash for {1} file with seed {2}...'.format(
                         i, filesize, hexseed))
                 hash = hashlib.sha256(
-                    RandomIO.RandomIO(seed).read(args.size)).hexdigest()
+                    RandomIO.RandomIO(hexseed).read(args.size)).hexdigest()
                 if (args.redis):
                     f.write(self._genredis(hexseed, hash))
                 else:
                     f.write('{0} {1} {2}\n'.format(hexseed, args.size, hash))
                 if (args.verbose):
                     print('done!')
+
+    def pairmatch(self):
+        parser = argparse.ArgumentParser(description='Output the hash of a file when given the seed and byte size.',
+                                         epilog='This tool can be used to return hash challenges for a Storj uptick or downstream service.')
+        parser.add_argument(
+            'size', type=int, help='The target size of each file generated and hashed (in bytes).')
+        parser.add_argument(
+            'seed', type=str, help='The seed of the file that you want to generate a hash for.')
+        args = parser.parse_args(sys.argv[2:])
+
+        print hashlib.sha256(RandomIO.RandomIO(args.seed).read(args.size)).hexdigest()
+
+
 
 if __name__ == '__main__':
     IOTools()

--- a/bin/IOTools.py
+++ b/bin/IOTools.py
@@ -97,7 +97,7 @@ Currently available commands include:
                 if (args.redis):
                     f.write(self._genredis(hexseed, hash))
                 else:
-                    f.write('{0} {1}\n'.format(hexseed, hash))
+                    f.write('{0} {1} {2}\n'.format(hexseed, args.size, hash))
                 if (args.verbose):
                     print('done!')
 

--- a/tests/tests-unit.py
+++ b/tests/tests-unit.py
@@ -161,7 +161,7 @@ class TestRandomIO(unittest.TestCase):
             for line in pairsfile:
                 (hexseed, filesize, hash) = line.rstrip().split(' ')
                 seed = binascii.unhexlify(hexseed)
-		self.assertEqual(size, filesize)
+		self.assertEqual(str(size), str(filesize))
                 testhash = hashlib.sha256(
                     RandomIO.RandomIO(seed).read(size)).hexdigest()
                 self.assertEqual(hash, testhash)

--- a/tests/tests-unit.py
+++ b/tests/tests-unit.py
@@ -159,8 +159,9 @@ class TestRandomIO(unittest.TestCase):
 
         with open(output, 'r') as pairsfile:
             for line in pairsfile:
-                (hexseed, hash) = line.rstrip().split(' ')
+                (hexseed, filesize, hash) = line.rstrip().split(' ')
                 seed = binascii.unhexlify(hexseed)
+		self.assertEqual(size, filesize)
                 testhash = hashlib.sha256(
                     RandomIO.RandomIO(seed).read(size)).hexdigest()
                 self.assertEqual(hash, testhash)

--- a/tests/tests-unit.py
+++ b/tests/tests-unit.py
@@ -161,7 +161,7 @@ class TestRandomIO(unittest.TestCase):
             for line in pairsfile:
                 (hexseed, filesize, hash) = line.rstrip().split(' ')
                 seed = binascii.unhexlify(hexseed)
-		self.assertEqual(str(size), str(filesize))
+                self.assertEqual(str(size), str(filesize))
                 testhash = hashlib.sha256(
                     RandomIO.RandomIO(seed).read(size)).hexdigest()
                 self.assertEqual(hash, testhash)


### PR DESCRIPTION
A little rough, and has no unit tests. Do we need to encode the seed, or just handle it in hex only?
